### PR TITLE
Fix: Add missing appcompat dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,6 +156,7 @@ kotlin {
 
 dependencies {
     // Core AndroidX
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 agp = "8.12.0"
 accompanist = "0.37.3"  # Update if needed
 activityCompose = "1.9.3"
+appcompat = "1.7.1"
 archCoreTesting = "2.2.0"
 coilCompose = "2.7.0"
 compose = "1.9.0"
@@ -83,6 +84,7 @@ firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "fireb
 
 [libraries]
 # AndroidX Core
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }


### PR DESCRIPTION
The Android build was failing with resource linking errors due to a missing dependency on `androidx.appcompat:appcompat`. The errors indicated that styles and attributes from the AppCompat theme were not found.

This change adds the `androidx.appcompat:appcompat` dependency to the project's Gradle configuration. The dependency version is managed in the `gradle/libs.versions.toml` file, and the dependency is included in the `app/build.gradle.kts` file.

This change should resolve the resource linking errors and allow the project to build successfully.